### PR TITLE
refactor: remove CA directory handling from Dockerfile and update README

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,6 @@ COPY . .
 # FIPS mode by default. The module is pure Go (no cgo required).
 ARG VERSION=devel
 RUN CGO_ENABLED=0 VERSION=${VERSION} make build
-RUN mkdir -p /ca-dir
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
@@ -29,16 +28,12 @@ WORKDIR /
 # Copy the binary from the builder stage
 COPY --from=builder /workspace/bin/otterscale .
 
-# Pre-create CA directory (distroless has no shell/mkdir)
-COPY --from=builder --chown=65532:65532 /ca-dir /var/lib/otterscale/ca
-
 # Switch to non-root user
 USER 65532:65532
 
 # Set environment variables
 ENV OTTERSCALE_SERVER_ADDRESS=0.0.0.0:8299
 ENV OTTERSCALE_SERVER_TUNNEL_ADDRESS=0.0.0.0:8300
-ENV OTTERSCALE_SERVER_TUNNEL_CA_DIR=/var/lib/otterscale/ca
 ENV GODEBUG=fips140=on
 
 # Expose ports (8299: HTTP/gRPC API, 8300: Tunnel)

--- a/README.md
+++ b/README.md
@@ -77,16 +77,15 @@ Env prefix: `OTTERSCALE_`, dots → underscores. Config file: `config.yaml` in `
 
 ### Server
 
-| ENV_VAR                                 | Default                  | Description                                 |
-| --------------------------------------- | ------------------------ | ------------------------------------------- |
-| `OTTERSCALE_SERVER_ADDRESS`             | `:8299`                  | HTTP listen address                         |
-| `OTTERSCALE_SERVER_ALLOWED_ORIGINS`     | —                        | CORS origins **(required)**                 |
-| `OTTERSCALE_SERVER_TUNNEL_ADDRESS`      | `127.0.0.1:8300`         | Chisel tunnel listen address                |
-| `OTTERSCALE_SERVER_TUNNEL_CA_DIR`       | `/var/lib/otterscale/ca` | Persistent CA cert/key directory            |
-| `OTTERSCALE_SERVER_KEYCLOAK_REALM_URL`  | —                        | OIDC issuer URL **(required)**              |
-| `OTTERSCALE_SERVER_KEYCLOAK_CLIENT_ID`  | `otterscale-server`      | Expected OIDC `aud` claim                   |
-| `OTTERSCALE_SERVER_EXTERNAL_URL`        | —                        | Public server URL for agents **(required)** |
-| `OTTERSCALE_SERVER_EXTERNAL_TUNNEL_URL` | —                        | Public tunnel URL for agents **(required)** |
+| ENV_VAR                                 | Default             | Description                                 |
+| --------------------------------------- | ------------------- | ------------------------------------------- |
+| `OTTERSCALE_SERVER_ADDRESS`             | `:8299`             | HTTP listen address                         |
+| `OTTERSCALE_SERVER_ALLOWED_ORIGINS`     | —                   | CORS origins **(required)**                 |
+| `OTTERSCALE_SERVER_TUNNEL_ADDRESS`      | `127.0.0.1:8300`    | Chisel tunnel listen address                |
+| `OTTERSCALE_SERVER_KEYCLOAK_REALM_URL`  | —                   | OIDC issuer URL **(required)**              |
+| `OTTERSCALE_SERVER_KEYCLOAK_CLIENT_ID`  | `otterscale-server` | Expected OIDC `aud` claim                   |
+| `OTTERSCALE_SERVER_EXTERNAL_URL`        | —                   | Public server URL for agents **(required)** |
+| `OTTERSCALE_SERVER_EXTERNAL_TUNNEL_URL` | —                   | Public tunnel URL for agents **(required)** |
 
 ### Agent
 


### PR DESCRIPTION
- Eliminated the creation and copying of the CA directory in the Dockerfile, simplifying the build process.
- Updated the README to reflect the removal of the OTTERSCALE_SERVER_TUNNEL_CA_DIR environment variable, ensuring accurate documentation of server configuration options.