### PR TITLE
refactor: replace context.Background() with t.Context() in tests for …

### DIFF
--- a/internal/cmd/agent/updater_test.go
+++ b/internal/cmd/agent/updater_test.go
@@ -1,7 +1,6 @@
 package agent
 
 import (
-	"context"
 	"strings"
 	"testing"
 
@@ -26,7 +25,7 @@ func TestPatch_InvalidVersion(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := u.Patch(context.Background(), tt.version)
+			err := u.Patch(t.Context(), tt.version)
 			if err == nil {
 				t.Errorf("expected error for version %q, got nil", tt.version)
 			}
@@ -51,7 +50,7 @@ func TestPatch_ValidVersion(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := u.Patch(context.Background(), tt.version)
+			err := u.Patch(t.Context(), tt.version)
 			if err == nil {
 				// If it succeeds we're probably in-cluster, which is fine.
 				return

--- a/internal/core/link_test.go
+++ b/internal/core/link_test.go
@@ -106,7 +106,7 @@ func TestLinkUseCase_ListLinks(t *testing.T) {
 	tp := &mockTunnelProvider{links: links}
 	uc := newTestLinkUseCase(t, tp, &mockManifestRenderer{})
 
-	got := uc.ListLinks(context.Background())
+	got := uc.ListLinks(t.Context())
 	if len(got) != 2 {
 		t.Fatalf("expected 2 clusters, got %d", len(got))
 	}
@@ -115,7 +115,6 @@ func TestLinkUseCase_ListLinks(t *testing.T) {
 func TestLinkUseCase_RegisterCluster_Validation(t *testing.T) {
 	tp := &mockTunnelProvider{regEndpoint: "127.0.0.1:8080", regCertPEM: []byte("cert")}
 	uc := newTestLinkUseCase(t, tp, &mockManifestRenderer{})
-	ctx := context.Background()
 
 	tests := []struct {
 		name    string
@@ -133,7 +132,7 @@ func TestLinkUseCase_RegisterCluster_Validation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := uc.RegisterCluster(ctx, tt.cluster, tt.agentID, "v1", tt.csr)
+			_, err := uc.RegisterCluster(t.Context(), tt.cluster, tt.agentID, "v1", tt.csr)
 			if err == nil {
 				t.Fatal("expected error, got nil")
 			}
@@ -156,7 +155,7 @@ func TestLinkUseCase_RegisterCluster_Success(t *testing.T) {
 	}
 	uc := newTestLinkUseCase(t, tp, &mockManifestRenderer{})
 
-	reg, err := uc.RegisterCluster(context.Background(), "my-cluster", "agent-1", "v1", []byte("csr-data"))
+	reg, err := uc.RegisterCluster(t.Context(), "my-cluster", "agent-1", "v1", []byte("csr-data"))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -177,9 +176,8 @@ func TestLinkUseCase_RegisterCluster_Success(t *testing.T) {
 func TestLinkUseCase_ManifestToken_IssueAndVerify(t *testing.T) {
 	tp := &mockTunnelProvider{}
 	uc := newTestLinkUseCase(t, tp, &mockManifestRenderer{})
-	ctx := context.Background()
 
-	url, err := uc.IssueManifestURL(ctx, "test-cluster", "user@example.com")
+	url, err := uc.IssueManifestURL(t.Context(), "test-cluster", "user@example.com")
 	if err != nil {
 		t.Fatalf("IssueManifestURL: %v", err)
 	}
@@ -191,7 +189,7 @@ func TestLinkUseCase_ManifestToken_IssueAndVerify(t *testing.T) {
 	}
 	token := parts[1]
 
-	cluster, userName, err := uc.VerifyManifestToken(ctx, token)
+	cluster, userName, err := uc.VerifyManifestToken(t.Context(), token)
 	if err != nil {
 		t.Fatalf("VerifyManifestToken: %v", err)
 	}
@@ -206,7 +204,6 @@ func TestLinkUseCase_ManifestToken_IssueAndVerify(t *testing.T) {
 func TestLinkUseCase_VerifyManifestToken_MalformedToken(t *testing.T) {
 	tp := &mockTunnelProvider{}
 	uc := newTestLinkUseCase(t, tp, &mockManifestRenderer{})
-	ctx := context.Background()
 
 	tests := []struct {
 		name  string
@@ -220,7 +217,7 @@ func TestLinkUseCase_VerifyManifestToken_MalformedToken(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, _, err := uc.VerifyManifestToken(ctx, tt.token)
+			_, _, err := uc.VerifyManifestToken(t.Context(), tt.token)
 			if err == nil {
 				t.Fatal("expected error, got nil")
 			}
@@ -231,9 +228,8 @@ func TestLinkUseCase_VerifyManifestToken_MalformedToken(t *testing.T) {
 func TestLinkUseCase_VerifyManifestToken_TamperedSignature(t *testing.T) {
 	tp := &mockTunnelProvider{}
 	uc := newTestLinkUseCase(t, tp, &mockManifestRenderer{})
-	ctx := context.Background()
 
-	url, err := uc.IssueManifestURL(ctx, "test-cluster", "user@example.com")
+	url, err := uc.IssueManifestURL(t.Context(), "test-cluster", "user@example.com")
 	if err != nil {
 		t.Fatalf("IssueManifestURL: %v", err)
 	}
@@ -245,7 +241,7 @@ func TestLinkUseCase_VerifyManifestToken_TamperedSignature(t *testing.T) {
 	tokenParts := strings.SplitN(token, ".", 2)
 	tampered := tokenParts[0] + ".dGFtcGVyZWQ"
 
-	_, _, err = uc.VerifyManifestToken(ctx, tampered)
+	_, _, err = uc.VerifyManifestToken(t.Context(), tampered)
 	if err == nil {
 		t.Fatal("expected error for tampered token")
 	}
@@ -258,7 +254,7 @@ func TestLinkUseCase_GenerateAgentManifest_Validation(t *testing.T) {
 	tp := &mockTunnelProvider{}
 	renderer := &mockManifestRenderer{result: "manifest-yaml"}
 	uc := newTestLinkUseCase(t, tp, renderer)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	tests := []struct {
 		name     string
@@ -286,7 +282,7 @@ func TestLinkUseCase_GenerateAgentManifest_Success(t *testing.T) {
 	renderer := &mockManifestRenderer{result: "---\napiVersion: v1\nkind: Namespace"}
 	uc := newTestLinkUseCase(t, tp, renderer)
 
-	manifest, err := uc.GenerateAgentManifest(context.Background(), "my-cluster", "admin@example.com")
+	manifest, err := uc.GenerateAgentManifest(t.Context(), "my-cluster", "admin@example.com")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/core/resource_test.go
+++ b/internal/core/resource_test.go
@@ -98,7 +98,7 @@ func TestResourceUseCase_Columns_Success(t *testing.T) {
 	cp := &mockColumnsProvider{columns: cols}
 	uc := NewResourceUseCase(disco, &mockResourceRepo{}, nil, cp)
 
-	result, err := uc.Columns(context.Background(), &ResourceIdentifier{
+	result, err := uc.Columns(t.Context(), &ResourceIdentifier{
 		Cluster:  "prod",
 		Group:    "apps",
 		Version:  "v1",
@@ -123,7 +123,7 @@ func TestResourceUseCase_Columns_LookupError(t *testing.T) {
 	cp := &mockColumnsProvider{}
 	uc := NewResourceUseCase(disco, &mockResourceRepo{}, nil, cp)
 
-	_, err := uc.Columns(context.Background(), &ResourceIdentifier{
+	_, err := uc.Columns(t.Context(), &ResourceIdentifier{
 		Cluster:  "prod",
 		Group:    "apps",
 		Version:  "v1",
@@ -139,7 +139,7 @@ func TestResourceUseCase_Columns_ProviderError(t *testing.T) {
 	cp := &mockColumnsProvider{err: errors.New("table API error")}
 	uc := NewResourceUseCase(disco, &mockResourceRepo{}, nil, cp)
 
-	_, err := uc.Columns(context.Background(), &ResourceIdentifier{
+	_, err := uc.Columns(t.Context(), &ResourceIdentifier{
 		Cluster:  "prod",
 		Group:    "",
 		Version:  "v1",
@@ -155,7 +155,7 @@ func TestResourceUseCase_Columns_Empty(t *testing.T) {
 	cp := &mockColumnsProvider{columns: []ColumnDefinition{}}
 	uc := NewResourceUseCase(disco, &mockResourceRepo{}, nil, cp)
 
-	result, err := uc.Columns(context.Background(), &ResourceIdentifier{
+	result, err := uc.Columns(t.Context(), &ResourceIdentifier{
 		Cluster:  "prod",
 		Group:    "",
 		Version:  "v1",

--- a/internal/core/runtime_test.go
+++ b/internal/core/runtime_test.go
@@ -88,7 +88,6 @@ func TestRuntimeUseCase_SubResourceAction_Validation(t *testing.T) {
 	disco := &mockDiscoveryForRuntime{}
 	repo := &mockRuntimeRepo{}
 	uc := newTestRuntimeUseCase(disco, repo)
-	ctx := context.Background()
 
 	tests := []struct {
 		name        string
@@ -136,7 +135,7 @@ func TestRuntimeUseCase_SubResourceAction_Validation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := uc.SubResourceAction(ctx, tt.id, tt.subresource, tt.method, nil)
+			_, err := uc.SubResourceAction(t.Context(), tt.id, tt.subresource, tt.method, nil)
 			if err == nil {
 				t.Fatal("expected error, got nil")
 			}
@@ -159,7 +158,7 @@ func TestRuntimeUseCase_SubResourceAction_Success(t *testing.T) {
 	uc := newTestRuntimeUseCase(disco, repo)
 
 	result, err := uc.SubResourceAction(
-		context.Background(),
+		t.Context(),
 		&ResourceIdentifier{
 			Cluster:   "prod",
 			Group:     "kubevirt.io",
@@ -188,7 +187,7 @@ func TestRuntimeUseCase_SubResourceAction_POST(t *testing.T) {
 	uc := newTestRuntimeUseCase(disco, repo)
 
 	result, err := uc.SubResourceAction(
-		context.Background(),
+		t.Context(),
 		&ResourceIdentifier{
 			Cluster:   "prod",
 			Group:     "kubevirt.io",
@@ -215,7 +214,7 @@ func TestRuntimeUseCase_SubResourceAction_LookupError(t *testing.T) {
 	uc := newTestRuntimeUseCase(disco, repo)
 
 	_, err := uc.SubResourceAction(
-		context.Background(),
+		t.Context(),
 		&ResourceIdentifier{
 			Cluster:   "prod",
 			Group:     "kubevirt.io",

--- a/internal/core/schema_composition_test.go
+++ b/internal/core/schema_composition_test.go
@@ -52,7 +52,7 @@ func TestComposingSchemaResolver_NonMatchingGVK(t *testing.T) {
 	}
 
 	resolver := NewComposingSchemaResolver(upstream)
-	schema, err := resolver.ResolveSchema(context.Background(), "cluster1", "apps", "v1", "Deployment")
+	schema, err := resolver.ResolveSchema(t.Context(), "cluster1", "apps", "v1", "Deployment")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -106,7 +106,7 @@ func TestComposingSchemaResolver_MatchingGVK(t *testing.T) {
 
 	resolver := NewComposingSchemaResolver(upstream)
 	schema, err := resolver.ResolveSchema(
-		context.Background(), "cluster1",
+		t.Context(), "cluster1",
 		"module.otterscale.io", "v1alpha1", "ModuleTemplate",
 	)
 	if err != nil {
@@ -151,7 +151,7 @@ func TestComposingSchemaResolver_TargetFetchError(t *testing.T) {
 
 	resolver := NewComposingSchemaResolver(upstream)
 	schema, err := resolver.ResolveSchema(
-		context.Background(), "cluster1",
+		t.Context(), "cluster1",
 		"module.otterscale.io", "v1alpha1", "ModuleTemplate",
 	)
 	if err != nil {
@@ -200,7 +200,7 @@ func TestComposingSchemaResolver_CacheNotCorrupted(t *testing.T) {
 
 	resolver := NewComposingSchemaResolver(upstream)
 	_, err := resolver.ResolveSchema(
-		context.Background(), "cluster1",
+		t.Context(), "cluster1",
 		"module.otterscale.io", "v1alpha1", "ModuleTemplate",
 	)
 	if err != nil {
@@ -260,7 +260,7 @@ func TestComposingSchemaResolver_SourceVersionMismatch(t *testing.T) {
 
 	// Request with v1alpha1 should NOT match the v1beta1-pinned rule.
 	schema, err := resolver.ResolveSchema(
-		context.Background(), "cluster1",
+		t.Context(), "cluster1",
 		"module.otterscale.io", "v1alpha1", "ModuleTemplate",
 	)
 	if err != nil {

--- a/internal/handler/proxy_test.go
+++ b/internal/handler/proxy_test.go
@@ -48,7 +48,7 @@ func TestProxyHandler_ForbiddenPath(t *testing.T) {
 			mux := http.NewServeMux()
 			mux.Handle("/proxy/{cluster}/prometheus/{path...}", handler)
 
-			req := httptest.NewRequest("GET", "/proxy/prod/prometheus"+tt.path, http.NoBody)
+			req := httptest.NewRequestWithContext(t.Context(), "GET", "/proxy/prod/prometheus"+tt.path, http.NoBody)
 			rec := httptest.NewRecorder()
 			mux.ServeHTTP(rec, req)
 
@@ -67,7 +67,7 @@ func TestProxyHandler_ClusterNotFound(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.Handle("/proxy/{cluster}/prometheus/{path...}", handler)
 
-	req := httptest.NewRequest("GET", "/proxy/missing/prometheus/api/v1/query?query=up", http.NoBody)
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "/proxy/missing/prometheus/api/v1/query?query=up", http.NoBody)
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
 
@@ -98,7 +98,7 @@ func TestProxyHandler_AllowedPath_ForwardsToBackend(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.Handle("/proxy/{cluster}/prometheus/{path...}", handler)
 
-	req := httptest.NewRequest("GET", "/proxy/prod/prometheus/api/v1/query?query=up", http.NoBody)
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "/proxy/prod/prometheus/api/v1/query?query=up", http.NoBody)
 	req.Header.Set("Authorization", "Bearer some-oidc-token")
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)

--- a/internal/providers/cache/discovery_cache_test.go
+++ b/internal/providers/cache/discovery_cache_test.go
@@ -56,11 +56,10 @@ func TestDiscoveryCache_Columns_CachesResult(t *testing.T) {
 
 	now := time.Now()
 	cache := NewDiscoveryCache(stub, 10*time.Minute, WithClock(func() time.Time { return now }))
-	ctx := context.Background()
 	gvr := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
 
 	// First call: hits upstream.
-	result, err := cache.Columns(ctx, "prod", gvr, "default")
+	result, err := cache.Columns(t.Context(), "prod", gvr, "default")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -72,7 +71,7 @@ func TestDiscoveryCache_Columns_CachesResult(t *testing.T) {
 	}
 
 	// Second call: served from cache.
-	result, err = cache.Columns(ctx, "prod", gvr, "default")
+	result, err = cache.Columns(t.Context(), "prod", gvr, "default")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -92,11 +91,10 @@ func TestDiscoveryCache_Columns_ExpiredEntry(t *testing.T) {
 
 	now := time.Now()
 	cache := NewDiscoveryCache(stub, 1*time.Minute, WithClock(func() time.Time { return now }))
-	ctx := context.Background()
 	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
 
 	// Populate cache.
-	_, _ = cache.Columns(ctx, "prod", gvr, "")
+	_, _ = cache.Columns(t.Context(), "prod", gvr, "")
 	if stub.callCount.Load() != 1 {
 		t.Fatalf("expected 1 call, got %d", stub.callCount.Load())
 	}
@@ -104,7 +102,7 @@ func TestDiscoveryCache_Columns_ExpiredEntry(t *testing.T) {
 	// Advance time past TTL.
 	now = now.Add(2 * time.Minute)
 
-	_, _ = cache.Columns(ctx, "prod", gvr, "")
+	_, _ = cache.Columns(t.Context(), "prod", gvr, "")
 	if stub.callCount.Load() != 2 {
 		t.Fatalf("expected 2 calls after TTL expiry, got %d", stub.callCount.Load())
 	}
@@ -115,13 +113,12 @@ func TestDiscoveryCache_Columns_DifferentKeys(t *testing.T) {
 	stub := &stubDiscovery{columns: cols}
 
 	cache := NewDiscoveryCache(stub, 10*time.Minute)
-	ctx := context.Background()
 
 	gvr1 := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
 	gvr2 := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
 
-	_, _ = cache.Columns(ctx, "prod", gvr1, "")
-	_, _ = cache.Columns(ctx, "prod", gvr2, "")
+	_, _ = cache.Columns(t.Context(), "prod", gvr1, "")
+	_, _ = cache.Columns(t.Context(), "prod", gvr2, "")
 
 	if stub.callCount.Load() != 2 {
 		t.Fatalf("expected 2 calls for different GVRs, got %d", stub.callCount.Load())
@@ -134,10 +131,9 @@ func TestDiscoveryCache_EvictExpiredColumns(t *testing.T) {
 
 	now := time.Now()
 	cache := NewDiscoveryCache(stub, 1*time.Minute, WithClock(func() time.Time { return now }))
-	ctx := context.Background()
 	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
 
-	_, _ = cache.Columns(ctx, "prod", gvr, "")
+	_, _ = cache.Columns(t.Context(), "prod", gvr, "")
 
 	cache.mu.RLock()
 	if len(cache.columnsCache) != 1 {

--- a/internal/transport/http/server_test.go
+++ b/internal/transport/http/server_test.go
@@ -13,9 +13,6 @@ import (
 func TestNewServer_PublicPathsBypassAuth(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
 	authMiddleware := authn.NewMiddleware(func(_ context.Context, r *http.Request) (any, error) {
 		if r.Header.Get("Authorization") == "" {
 			return nil, authn.Errorf("missing bearer token")
@@ -24,14 +21,14 @@ func TestNewServer_PublicPathsBypassAuth(t *testing.T) {
 	})
 
 	var lc net.ListenConfig
-	ln, err := lc.Listen(ctx, "tcp", "127.0.0.1:0")
+	ln, err := lc.Listen(t.Context(), "tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("listen: %v", err)
 	}
 	defer ln.Close()
 
 	srv, err := NewServer(
-		ctx,
+		t.Context(),
 		WithListener(ln),
 		WithAuthMiddleware(authMiddleware),
 		WithAllowedOrigins([]string{"https://example.com"}),
@@ -51,7 +48,7 @@ func TestNewServer_PublicPathsBypassAuth(t *testing.T) {
 	}
 
 	t.Run("public path without token is allowed", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodGet, "/public", http.NoBody)
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/public", http.NoBody)
 		rec := httptest.NewRecorder()
 		srv.Handler().ServeHTTP(rec, req)
 
@@ -61,7 +58,7 @@ func TestNewServer_PublicPathsBypassAuth(t *testing.T) {
 	})
 
 	t.Run("private path without token is blocked", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodGet, "/private", http.NoBody)
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/private", http.NoBody)
 		rec := httptest.NewRecorder()
 		srv.Handler().ServeHTTP(rec, req)
 
@@ -71,7 +68,7 @@ func TestNewServer_PublicPathsBypassAuth(t *testing.T) {
 	})
 
 	t.Run("private path with token is allowed", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodGet, "/private", http.NoBody)
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/private", http.NoBody)
 		req.Header.Set("Authorization", "Bearer test-token")
 		rec := httptest.NewRecorder()
 		srv.Handler().ServeHTTP(rec, req)

--- a/internal/transport/tunnel/bridge_test.go
+++ b/internal/transport/tunnel/bridge_test.go
@@ -17,19 +17,16 @@ import (
 func TestBridge_RelaysData(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
 	pl := pipe.NewListener()
 	defer pl.Close()
 
-	bridge, err := NewBridge(ctx, pl)
+	bridge, err := NewBridge(t.Context(), pl)
 	if err != nil {
 		t.Fatalf("NewBridge: %v", err)
 	}
 
 	go func() {
-		if err := bridge.Start(ctx); err != nil {
+		if err := bridge.Start(t.Context()); err != nil {
 			t.Logf("bridge.Start: %v", err)
 		}
 	}()
@@ -56,7 +53,7 @@ func TestBridge_RelaysData(t *testing.T) {
 
 	// Client side: connect to the bridge TCP port, send request, read response.
 	var d net.Dialer
-	tcpConn, err := d.DialContext(ctx, "tcp", fmt.Sprintf("127.0.0.1:%d", bridge.Port()))
+	tcpConn, err := d.DialContext(t.Context(), "tcp", fmt.Sprintf("127.0.0.1:%d", bridge.Port()))
 	if err != nil {
 		t.Fatalf("tcp dial: %v", err)
 	}
@@ -80,19 +77,16 @@ func TestBridge_RelaysData(t *testing.T) {
 func TestBridge_MultipleConnections(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
 	pl := pipe.NewListener()
 	defer pl.Close()
 
-	bridge, err := NewBridge(ctx, pl)
+	bridge, err := NewBridge(t.Context(), pl)
 	if err != nil {
 		t.Fatalf("NewBridge: %v", err)
 	}
 
 	go func() {
-		if err := bridge.Start(ctx); err != nil {
+		if err := bridge.Start(t.Context()); err != nil {
 			t.Logf("bridge.Start: %v", err)
 		}
 	}()
@@ -115,12 +109,11 @@ func TestBridge_MultipleConnections(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			verifyRoundTrip(ctx, t, addr, i)
+			verifyRoundTrip(t.Context(), t, addr, i)
 		}()
 	}
 
 	wg.Wait()
-	cancel()
 }
 
 // echoConnection accepts a pipe connection, reads a message, and
@@ -176,18 +169,15 @@ func verifyRoundTrip(ctx context.Context, t *testing.T, addr string, i int) {
 func TestBridge_PortIsNonZero(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
 	pl := pipe.NewListener()
 	defer pl.Close()
 
-	bridge, err := NewBridge(ctx, pl)
+	bridge, err := NewBridge(t.Context(), pl)
 	if err != nil {
 		t.Fatalf("NewBridge: %v", err)
 	}
 	defer func() {
-		if err := bridge.Stop(context.Background()); err != nil {
+		if err := bridge.Stop(t.Context()); err != nil {
 			t.Logf("bridge.Stop: %v", err)
 		}
 	}()
@@ -200,12 +190,14 @@ func TestBridge_PortIsNonZero(t *testing.T) {
 func TestBridge_StopClosesListener(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithCancel(context.Background())
 	pl := pipe.NewListener()
-	bridge, err := NewBridge(ctx, pl)
+	bridge, err := NewBridge(t.Context(), pl)
 	if err != nil {
 		t.Fatalf("NewBridge: %v", err)
 	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
 
 	done := make(chan error, 1)
 	go func() {

--- a/test/integration/tunnel_test.go
+++ b/test/integration/tunnel_test.go
@@ -1,7 +1,6 @@
 package integration
 
 import (
-	"context"
 	"maps"
 	"slices"
 	"strings"
@@ -25,13 +24,11 @@ func TestLinkRegisterClusterUsesSingleSharedTunnelPort(t *testing.T) {
 	csrA := generateCSR(t, "agent-a")
 	csrB := generateCSR(t, "agent-b")
 
-	ctx := context.Background()
-
-	regA, err := link.RegisterCluster(ctx, "cluster-a", "agent-a", "test", csrA)
+	regA, err := link.RegisterCluster(t.Context(), "cluster-a", "agent-a", "test", csrA)
 	if err != nil {
 		t.Fatalf("register cluster-a: %v", err)
 	}
-	regB, err := link.RegisterCluster(ctx, "cluster-b", "agent-b", "test", csrB)
+	regB, err := link.RegisterCluster(t.Context(), "cluster-b", "agent-b", "test", csrB)
 	if err != nil {
 		t.Fatalf("register cluster-b: %v", err)
 	}
@@ -50,11 +47,11 @@ func TestLinkRegisterClusterUsesSingleSharedTunnelPort(t *testing.T) {
 		t.Fatalf("expected distinct endpoints for different clusters, got %q", regA.Endpoint)
 	}
 
-	addrA, err := tunnel.ResolveAddress(ctx, "cluster-a")
+	addrA, err := tunnel.ResolveAddress(t.Context(), "cluster-a")
 	if err != nil {
 		t.Fatalf("resolve cluster-a: %v", err)
 	}
-	addrB, err := tunnel.ResolveAddress(ctx, "cluster-b")
+	addrB, err := tunnel.ResolveAddress(t.Context(), "cluster-b")
 	if err != nil {
 		t.Fatalf("resolve cluster-b: %v", err)
 	}
@@ -75,20 +72,18 @@ func TestLinkRegisterClusterLatestAgentWinsForSameCluster(t *testing.T) {
 	csr1 := generateCSR(t, "agent-r-1")
 	csr2 := generateCSR(t, "agent-r-2")
 
-	ctx := context.Background()
-
-	_, err = link.RegisterCluster(ctx, "cluster-r", "agent-r-1", "test", csr1)
+	_, err = link.RegisterCluster(t.Context(), "cluster-r", "agent-r-1", "test", csr1)
 	if err != nil {
 		t.Fatalf("register agent-r-1: %v", err)
 	}
-	reg2, err := link.RegisterCluster(ctx, "cluster-r", "agent-r-2", "test", csr2)
+	reg2, err := link.RegisterCluster(t.Context(), "cluster-r", "agent-r-2", "test", csr2)
 	if err != nil {
 		t.Fatalf("register agent-r-2: %v", err)
 	}
 
 	// After re-registration the route must resolve to the latest
 	// agent's endpoint regardless of whether the host was reused.
-	addr, err := tunnel.ResolveAddress(ctx, "cluster-r")
+	addr, err := tunnel.ResolveAddress(t.Context(), "cluster-r")
 	if err != nil {
 		t.Fatalf("resolve: %v", err)
 	}
@@ -114,21 +109,19 @@ func TestLinkRegisterClusterReregisterAndReplaceAcrossAgents(t *testing.T) {
 	csrA := generateCSR(t, "agent-a")
 	csrB := generateCSR(t, "agent-b")
 
-	ctx := context.Background()
-
-	regA1, err := link.RegisterCluster(ctx, "cluster-z", "agent-a", "test", csrA)
+	regA1, err := link.RegisterCluster(t.Context(), "cluster-z", "agent-a", "test", csrA)
 	if err != nil {
 		t.Fatalf("register agent-a #1: %v", err)
 	}
 
-	regB, err := link.RegisterCluster(ctx, "cluster-z", "agent-b", "test", csrB)
+	regB, err := link.RegisterCluster(t.Context(), "cluster-z", "agent-b", "test", csrB)
 	if err != nil {
 		t.Fatalf("register agent-b: %v", err)
 	}
 
 	// After re-registration for the same cluster, the route must
 	// resolve to the latest agent's endpoint.
-	addrB, err := tunnel.ResolveAddress(ctx, "cluster-z")
+	addrB, err := tunnel.ResolveAddress(t.Context(), "cluster-z")
 	if err != nil {
 		t.Fatalf("resolve after agent-b register: %v", err)
 	}
@@ -136,7 +129,7 @@ func TestLinkRegisterClusterReregisterAndReplaceAcrossAgents(t *testing.T) {
 		t.Fatalf("expected resolve to point to agent-b endpoint %q, got %q", regB.Endpoint, addrB)
 	}
 
-	regA2, err := link.RegisterCluster(ctx, "cluster-z", "agent-a", "test", csrA)
+	regA2, err := link.RegisterCluster(t.Context(), "cluster-z", "agent-a", "test", csrA)
 	if err != nil {
 		t.Fatalf("register agent-a #2: %v", err)
 	}
@@ -156,7 +149,7 @@ func TestLinkRegisterClusterReregisterAndReplaceAcrossAgents(t *testing.T) {
 	}
 
 	for i := 0; i < 3; i++ {
-		addr, err := tunnel.ResolveAddress(ctx, "cluster-z")
+		addr, err := tunnel.ResolveAddress(t.Context(), "cluster-z")
 		if err != nil {
 			t.Fatalf("resolve #%d: %v", i+1, err)
 		}
@@ -187,7 +180,7 @@ func initTunnelServer(t *testing.T, tunnel *chisel.Service) {
 		t.Fatalf("init tunnel server: %v", err)
 	}
 	t.Cleanup(func() {
-		_ = srv.Stop(context.Background())
+		_ = srv.Stop(t.Context())
 	})
 }
 


### PR DESCRIPTION
…improved context handling

- Updated multiple test files to use t.Context() instead of context.Background() for better context management and consistency across tests.
- This change enhances the integration of context within test cases, ensuring that any context-related features are properly utilized.