### PR TITLE
feat: add fallback to local kubeconfig for debugging in impersonation…

### DIFF
--- a/internal/providers/kubernetes/kubernetes.go
+++ b/internal/providers/kubernetes/kubernetes.go
@@ -11,10 +11,12 @@ package kubernetes
 import (
 	"context"
 	"net/http"
+	"os"
 	"sync"
 	"time"
 
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/otterscale/otterscale/internal/core"
 )
@@ -64,6 +66,11 @@ func (k *Kubernetes) impersonationConfig(ctx context.Context, cluster string) (*
 			Code:    core.ErrorCodeUnauthenticated,
 			Message: "user info not found in context",
 		}
+	}
+
+	// fallback to local kubeconfig for debugging
+	if os.Getenv("OTTERSCALE_DEBUG") != "" {
+		return clientcmd.BuildConfigFromFlags("", clientcmd.RecommendedHomeFile)
 	}
 
 	address, err := k.tunnel.ResolveAddress(ctx, cluster)


### PR DESCRIPTION
…Config

- Implemented a fallback mechanism in the impersonationConfig function to use the local kubeconfig when the OTTERSCALE_DEBUG environment variable is set, enhancing debugging capabilities.