### PR TITLE
feat: add namespace scope validation for Kubernetes resources

### DIFF
--- a/internal/core/resource.go
+++ b/internal/core/resource.go
@@ -38,8 +38,8 @@ import (
 // depending on a concrete client implementation.
 type DiscoveryClient interface {
 	// LookupResource validates that a group/version/resource triple
-	// exists on the target cluster.
-	LookupResource(ctx context.Context, cluster, group, version, resource, subresource string) (schema.GroupVersionResource, error)
+	// exists on the target cluster and returns whether it is namespace-scoped.
+	LookupResource(ctx context.Context, cluster, group, version, resource, subresource string) (gvr schema.GroupVersionResource, isNamespaced bool, err error)
 	// ServerResources returns all API resources advertised by the cluster.
 	ServerResources(ctx context.Context, cluster string) ([]*metav1.APIResourceList, error)
 	// ResolveSchema fetches the OpenAPI schema for a given GVK.
@@ -49,9 +49,6 @@ type DiscoveryClient interface {
 	// SupportsWatchList reports whether the target cluster supports
 	// the WatchList streaming feature (Kubernetes >= 1.34).
 	SupportsWatchList(ctx context.Context, cluster string) (bool, error)
-	// IsNamespacedResource reports whether the given resource is
-	// namespace-scoped (true) or cluster-scoped (false).
-	IsNamespacedResource(ctx context.Context, cluster string, gvr schema.GroupVersionResource) (bool, error)
 }
 
 // ResourceRepo abstracts Kubernetes resource CRUD and watch operations
@@ -157,20 +154,16 @@ type ResourceIdentifier struct {
 	Name        string
 }
 
-// lookupGVR validates the resource triple via the DiscoveryClient.
-func (id *ResourceIdentifier) lookupGVR(ctx context.Context, dc DiscoveryClient) (schema.GroupVersionResource, error) {
+// lookupGVR validates the resource triple via the DiscoveryClient
+// and returns both the GVR and whether it is namespace-scoped.
+func (id *ResourceIdentifier) lookupGVR(ctx context.Context, dc DiscoveryClient) (schema.GroupVersionResource, bool, error) {
 	return dc.LookupResource(ctx, id.Cluster, id.Group, id.Version, id.Resource, id.SubResource)
 }
 
 // validateNamespaceScope checks if the namespace parameter matches the
 // resource's scope (namespace-scoped or cluster-scoped) and returns a
 // clear validation error if there's a mismatch.
-func (id *ResourceIdentifier) validateNamespaceScope(ctx context.Context, dc DiscoveryClient, gvr schema.GroupVersionResource) error {
-	isNamespaced, err := dc.IsNamespacedResource(ctx, id.Cluster, gvr)
-	if err != nil {
-		return err
-	}
-
+func (id *ResourceIdentifier) validateNamespaceScope(gvr schema.GroupVersionResource, isNamespaced bool) error {
 	if !isNamespaced && id.Namespace != "" {
 		return &ErrInvalidInput{
 			Field:   "namespace",
@@ -234,12 +227,12 @@ func (uc *ResourceUseCase) ListResources(
 	id *ResourceIdentifier,
 	opts ListOptions,
 ) (*unstructured.UnstructuredList, error) {
-	gvr, err := id.lookupGVR(ctx, uc.discovery)
+	gvr, isNamespaced, err := id.lookupGVR(ctx, uc.discovery)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := id.validateNamespaceScope(ctx, uc.discovery, gvr); err != nil {
+	if err := id.validateNamespaceScope(gvr, isNamespaced); err != nil {
 		return nil, err
 	}
 
@@ -251,12 +244,12 @@ func (uc *ResourceUseCase) GetResource(
 	ctx context.Context,
 	id *ResourceIdentifier,
 ) (*unstructured.Unstructured, error) {
-	gvr, err := id.lookupGVR(ctx, uc.discovery)
+	gvr, isNamespaced, err := id.lookupGVR(ctx, uc.discovery)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := id.validateNamespaceScope(ctx, uc.discovery, gvr); err != nil {
+	if err := id.validateNamespaceScope(gvr, isNamespaced); err != nil {
 		return nil, err
 	}
 
@@ -271,12 +264,12 @@ func (uc *ResourceUseCase) DescribeResource(
 	ctx context.Context,
 	id *ResourceIdentifier,
 ) (*unstructured.Unstructured, *unstructured.UnstructuredList, error) {
-	gvr, err := id.lookupGVR(ctx, uc.discovery)
+	gvr, isNamespaced, err := id.lookupGVR(ctx, uc.discovery)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	if err := id.validateNamespaceScope(ctx, uc.discovery, gvr); err != nil {
+	if err := id.validateNamespaceScope(gvr, isNamespaced); err != nil {
 		return nil, nil, err
 	}
 
@@ -306,12 +299,12 @@ func (uc *ResourceUseCase) CreateResource(
 	id *ResourceIdentifier,
 	manifest []byte,
 ) (*unstructured.Unstructured, error) {
-	gvr, err := id.lookupGVR(ctx, uc.discovery)
+	gvr, isNamespaced, err := id.lookupGVR(ctx, uc.discovery)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := id.validateNamespaceScope(ctx, uc.discovery, gvr); err != nil {
+	if err := id.validateNamespaceScope(gvr, isNamespaced); err != nil {
 		return nil, err
 	}
 
@@ -326,12 +319,12 @@ func (uc *ResourceUseCase) ApplyResource(
 	manifest []byte,
 	opts ApplyOptions,
 ) (*unstructured.Unstructured, error) {
-	gvr, err := id.lookupGVR(ctx, uc.discovery)
+	gvr, isNamespaced, err := id.lookupGVR(ctx, uc.discovery)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := id.validateNamespaceScope(ctx, uc.discovery, gvr); err != nil {
+	if err := id.validateNamespaceScope(gvr, isNamespaced); err != nil {
 		return nil, err
 	}
 
@@ -344,12 +337,12 @@ func (uc *ResourceUseCase) DeleteResource(
 	id *ResourceIdentifier,
 	opts DeleteOptions,
 ) error {
-	gvr, err := id.lookupGVR(ctx, uc.discovery)
+	gvr, isNamespaced, err := id.lookupGVR(ctx, uc.discovery)
 	if err != nil {
 		return err
 	}
 
-	if err := id.validateNamespaceScope(ctx, uc.discovery, gvr); err != nil {
+	if err := id.validateNamespaceScope(gvr, isNamespaced); err != nil {
 		return err
 	}
 
@@ -364,12 +357,12 @@ func (uc *ResourceUseCase) WatchResource(
 	id *ResourceIdentifier,
 	opts WatchOptions,
 ) (Watcher, error) {
-	gvr, err := id.lookupGVR(ctx, uc.discovery)
+	gvr, isNamespaced, err := id.lookupGVR(ctx, uc.discovery)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := id.validateNamespaceScope(ctx, uc.discovery, gvr); err != nil {
+	if err := id.validateNamespaceScope(gvr, isNamespaced); err != nil {
 		return nil, err
 	}
 

--- a/internal/core/resource.go
+++ b/internal/core/resource.go
@@ -49,6 +49,9 @@ type DiscoveryClient interface {
 	// SupportsWatchList reports whether the target cluster supports
 	// the WatchList streaming feature (Kubernetes >= 1.34).
 	SupportsWatchList(ctx context.Context, cluster string) (bool, error)
+	// IsNamespacedResource reports whether the given resource is
+	// namespace-scoped (true) or cluster-scoped (false).
+	IsNamespacedResource(ctx context.Context, cluster string, gvr schema.GroupVersionResource) (bool, error)
 }
 
 // ResourceRepo abstracts Kubernetes resource CRUD and watch operations
@@ -159,6 +162,32 @@ func (id *ResourceIdentifier) lookupGVR(ctx context.Context, dc DiscoveryClient)
 	return dc.LookupResource(ctx, id.Cluster, id.Group, id.Version, id.Resource, id.SubResource)
 }
 
+// validateNamespaceScope checks if the namespace parameter matches the
+// resource's scope (namespace-scoped or cluster-scoped) and returns a
+// clear validation error if there's a mismatch.
+func (id *ResourceIdentifier) validateNamespaceScope(ctx context.Context, dc DiscoveryClient, gvr schema.GroupVersionResource) error {
+	isNamespaced, err := dc.IsNamespacedResource(ctx, id.Cluster, gvr)
+	if err != nil {
+		return err
+	}
+
+	if !isNamespaced && id.Namespace != "" {
+		return &ErrInvalidInput{
+			Field:   "namespace",
+			Message: fmt.Sprintf("resource '%s' is cluster-scoped and cannot have a namespace", gvr.Resource),
+		}
+	}
+
+	if isNamespaced && id.Namespace == "" {
+		return &ErrInvalidInput{
+			Field:   "namespace",
+			Message: fmt.Sprintf("resource '%s' is namespace-scoped and requires a namespace", gvr.Resource),
+		}
+	}
+
+	return nil
+}
+
 // ---------------------------------------------------------------------------
 // Use case
 // ---------------------------------------------------------------------------
@@ -210,6 +239,10 @@ func (uc *ResourceUseCase) ListResources(
 		return nil, err
 	}
 
+	if err := id.validateNamespaceScope(ctx, uc.discovery, gvr); err != nil {
+		return nil, err
+	}
+
 	return uc.resource.List(ctx, id.Cluster, gvr, id.Namespace, opts)
 }
 
@@ -220,6 +253,10 @@ func (uc *ResourceUseCase) GetResource(
 ) (*unstructured.Unstructured, error) {
 	gvr, err := id.lookupGVR(ctx, uc.discovery)
 	if err != nil {
+		return nil, err
+	}
+
+	if err := id.validateNamespaceScope(ctx, uc.discovery, gvr); err != nil {
 		return nil, err
 	}
 
@@ -236,6 +273,10 @@ func (uc *ResourceUseCase) DescribeResource(
 ) (*unstructured.Unstructured, *unstructured.UnstructuredList, error) {
 	gvr, err := id.lookupGVR(ctx, uc.discovery)
 	if err != nil {
+		return nil, nil, err
+	}
+
+	if err := id.validateNamespaceScope(ctx, uc.discovery, gvr); err != nil {
 		return nil, nil, err
 	}
 
@@ -270,6 +311,10 @@ func (uc *ResourceUseCase) CreateResource(
 		return nil, err
 	}
 
+	if err := id.validateNamespaceScope(ctx, uc.discovery, gvr); err != nil {
+		return nil, err
+	}
+
 	return uc.resource.Create(ctx, id.Cluster, gvr, id.Namespace, manifest)
 }
 
@@ -283,6 +328,10 @@ func (uc *ResourceUseCase) ApplyResource(
 ) (*unstructured.Unstructured, error) {
 	gvr, err := id.lookupGVR(ctx, uc.discovery)
 	if err != nil {
+		return nil, err
+	}
+
+	if err := id.validateNamespaceScope(ctx, uc.discovery, gvr); err != nil {
 		return nil, err
 	}
 
@@ -300,6 +349,10 @@ func (uc *ResourceUseCase) DeleteResource(
 		return err
 	}
 
+	if err := id.validateNamespaceScope(ctx, uc.discovery, gvr); err != nil {
+		return err
+	}
+
 	return uc.resource.Delete(ctx, id.Cluster, gvr, id.Namespace, id.Name, opts)
 }
 
@@ -313,6 +366,10 @@ func (uc *ResourceUseCase) WatchResource(
 ) (Watcher, error) {
 	gvr, err := id.lookupGVR(ctx, uc.discovery)
 	if err != nil {
+		return nil, err
+	}
+
+	if err := id.validateNamespaceScope(ctx, uc.discovery, gvr); err != nil {
 		return nil, err
 	}
 

--- a/internal/core/resource_test.go
+++ b/internal/core/resource_test.go
@@ -1,0 +1,409 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/version"
+	"k8s.io/kube-openapi/pkg/validation/spec"
+)
+
+// mockDiscoveryForResource implements DiscoveryClient for resource tests.
+type mockDiscoveryForResource struct {
+	lookupGVR         schema.GroupVersionResource
+	lookupNamespaced  bool
+	lookupErr         error
+	supportsWatchList bool
+}
+
+func (m *mockDiscoveryForResource) LookupResource(_ context.Context, _, group, ver, resource, _ string) (schema.GroupVersionResource, bool, error) {
+	if m.lookupErr != nil {
+		return schema.GroupVersionResource{}, false, m.lookupErr
+	}
+	if m.lookupGVR.Empty() {
+		return schema.GroupVersionResource{Group: group, Version: ver, Resource: resource}, m.lookupNamespaced, nil
+	}
+	return m.lookupGVR, m.lookupNamespaced, nil
+}
+
+func (m *mockDiscoveryForResource) ServerResources(context.Context, string) ([]*metav1.APIResourceList, error) {
+	return nil, nil
+}
+
+func (m *mockDiscoveryForResource) ResolveSchema(context.Context, string, string, string, string) (*spec.Schema, error) {
+	return nil, nil
+}
+
+func (m *mockDiscoveryForResource) ServerVersion(context.Context, string) (*version.Info, error) {
+	return nil, nil
+}
+
+func (m *mockDiscoveryForResource) SupportsWatchList(context.Context, string) (bool, error) {
+	return m.supportsWatchList, nil
+}
+
+// TestResourceIdentifier_validateNamespaceScope tests the namespace scope validation logic.
+func TestResourceIdentifier_validateNamespaceScope(t *testing.T) {
+	tests := []struct {
+		name         string
+		id           *ResourceIdentifier
+		gvr          schema.GroupVersionResource
+		isNamespaced bool
+		wantErr      bool
+		wantErrField string
+		wantErrMsg   string
+	}{
+		{
+			name: "cluster-scoped resource with namespace should error",
+			id: &ResourceIdentifier{
+				Namespace: "default",
+			},
+			gvr: schema.GroupVersionResource{
+				Group:    "apiextensions.k8s.io",
+				Version:  "v1",
+				Resource: "customresourcedefinitions",
+			},
+			isNamespaced: false,
+			wantErr:      true,
+			wantErrField: "namespace",
+			wantErrMsg:   "cluster-scoped and cannot have a namespace",
+		},
+		{
+			name: "cluster-scoped resource without namespace should pass",
+			id: &ResourceIdentifier{
+				Namespace: "",
+			},
+			gvr: schema.GroupVersionResource{
+				Group:    "apiextensions.k8s.io",
+				Version:  "v1",
+				Resource: "customresourcedefinitions",
+			},
+			isNamespaced: false,
+			wantErr:      false,
+		},
+		{
+			name: "namespace-scoped resource without namespace should error",
+			id: &ResourceIdentifier{
+				Namespace: "",
+			},
+			gvr: schema.GroupVersionResource{
+				Group:    "",
+				Version:  "v1",
+				Resource: "pods",
+			},
+			isNamespaced: true,
+			wantErr:      true,
+			wantErrField: "namespace",
+			wantErrMsg:   "namespace-scoped and requires a namespace",
+		},
+		{
+			name: "namespace-scoped resource with namespace should pass",
+			id: &ResourceIdentifier{
+				Namespace: "default",
+			},
+			gvr: schema.GroupVersionResource{
+				Group:    "",
+				Version:  "v1",
+				Resource: "pods",
+			},
+			isNamespaced: true,
+			wantErr:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.id.validateNamespaceScope(tt.gvr, tt.isNamespaced)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateNamespaceScope() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if err != nil {
+				var invalidInput *ErrInvalidInput
+				if !errors.As(err, &invalidInput) {
+					t.Fatalf("expected ErrInvalidInput, got %T: %v", err, err)
+				}
+				if invalidInput.Field != tt.wantErrField {
+					t.Errorf("field = %q, want %q", invalidInput.Field, tt.wantErrField)
+				}
+				if tt.wantErrMsg != "" && !contains(err.Error(), tt.wantErrMsg) {
+					t.Errorf("error message = %q, want to contain %q", err.Error(), tt.wantErrMsg)
+				}
+			}
+		})
+	}
+}
+
+// TestResourceUseCase_CreateResource_NamespaceValidation tests namespace scope validation in CreateResource.
+func TestResourceUseCase_CreateResource_NamespaceValidation(t *testing.T) {
+	tests := []struct {
+		name         string
+		id           *ResourceIdentifier
+		isNamespaced bool
+		wantErr      bool
+		wantErrMsg   string
+	}{
+		{
+			name: "create cluster-scoped resource with namespace should fail",
+			id: &ResourceIdentifier{
+				Cluster:   "test-cluster",
+				Group:     "apiextensions.k8s.io",
+				Version:   "v1",
+				Resource:  "customresourcedefinitions",
+				Namespace: "default",
+			},
+			isNamespaced: false,
+			wantErr:      true,
+			wantErrMsg:   "cluster-scoped and cannot have a namespace",
+		},
+		{
+			name: "create namespace-scoped resource without namespace should fail",
+			id: &ResourceIdentifier{
+				Cluster:   "test-cluster",
+				Group:     "",
+				Version:   "v1",
+				Resource:  "pods",
+				Namespace: "",
+			},
+			isNamespaced: true,
+			wantErr:      true,
+			wantErrMsg:   "namespace-scoped and requires a namespace",
+		},
+		{
+			name: "create cluster-scoped resource without namespace should succeed",
+			id: &ResourceIdentifier{
+				Cluster:   "test-cluster",
+				Group:     "apiextensions.k8s.io",
+				Version:   "v1",
+				Resource:  "customresourcedefinitions",
+				Namespace: "",
+			},
+			isNamespaced: false,
+			wantErr:      false,
+		},
+		{
+			name: "create namespace-scoped resource with namespace should succeed",
+			id: &ResourceIdentifier{
+				Cluster:   "test-cluster",
+				Group:     "",
+				Version:   "v1",
+				Resource:  "pods",
+				Namespace: "default",
+			},
+			isNamespaced: true,
+			wantErr:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			disco := &mockDiscoveryForResource{
+				lookupNamespaced: tt.isNamespaced,
+			}
+			repo := &mockResourceRepo{}
+			uc := NewResourceUseCase(disco, repo, nil)
+
+			_, err := uc.CreateResource(context.Background(), tt.id, []byte("manifest"))
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CreateResource() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if err != nil && tt.wantErrMsg != "" && !contains(err.Error(), tt.wantErrMsg) {
+				t.Errorf("error message = %q, want to contain %q", err.Error(), tt.wantErrMsg)
+			}
+		})
+	}
+}
+
+// TestResourceUseCase_GetResource_NamespaceValidation tests namespace scope validation in GetResource.
+func TestResourceUseCase_GetResource_NamespaceValidation(t *testing.T) {
+	disco := &mockDiscoveryForResource{
+		lookupNamespaced: false, // cluster-scoped
+	}
+	repo := &mockResourceRepo{}
+	uc := NewResourceUseCase(disco, repo, nil)
+
+	id := &ResourceIdentifier{
+		Cluster:   "test-cluster",
+		Group:     "apiextensions.k8s.io",
+		Version:   "v1",
+		Resource:  "customresourcedefinitions",
+		Namespace: "default", // should fail
+		Name:      "test-crd",
+	}
+
+	_, err := uc.GetResource(context.Background(), id)
+	if err == nil {
+		t.Fatal("expected error for cluster-scoped resource with namespace, got nil")
+	}
+
+	var invalidInput *ErrInvalidInput
+	if !errors.As(err, &invalidInput) {
+		t.Fatalf("expected ErrInvalidInput, got %T: %v", err, err)
+	}
+	if !contains(err.Error(), "cluster-scoped") {
+		t.Errorf("error message = %q, want to contain 'cluster-scoped'", err.Error())
+	}
+}
+
+// TestResourceUseCase_ListResources_NamespaceValidation tests namespace scope validation in ListResources.
+func TestResourceUseCase_ListResources_NamespaceValidation(t *testing.T) {
+	disco := &mockDiscoveryForResource{
+		lookupNamespaced: true, // namespace-scoped
+	}
+	repo := &mockResourceRepo{}
+	uc := NewResourceUseCase(disco, repo, nil)
+
+	id := &ResourceIdentifier{
+		Cluster:   "test-cluster",
+		Group:     "",
+		Version:   "v1",
+		Resource:  "pods",
+		Namespace: "", // should fail
+	}
+
+	_, err := uc.ListResources(context.Background(), id, ListOptions{})
+	if err == nil {
+		t.Fatal("expected error for namespace-scoped resource without namespace, got nil")
+	}
+
+	var invalidInput *ErrInvalidInput
+	if !errors.As(err, &invalidInput) {
+		t.Fatalf("expected ErrInvalidInput, got %T: %v", err, err)
+	}
+	if !contains(err.Error(), "requires a namespace") {
+		t.Errorf("error message = %q, want to contain 'requires a namespace'", err.Error())
+	}
+}
+
+// TestResourceUseCase_ApplyResource_NamespaceValidation tests namespace scope validation in ApplyResource.
+func TestResourceUseCase_ApplyResource_NamespaceValidation(t *testing.T) {
+	disco := &mockDiscoveryForResource{
+		lookupNamespaced: false, // cluster-scoped
+	}
+	repo := &mockResourceRepo{}
+	uc := NewResourceUseCase(disco, repo, nil)
+
+	id := &ResourceIdentifier{
+		Cluster:   "test-cluster",
+		Group:     "apiextensions.k8s.io",
+		Version:   "v1",
+		Resource:  "customresourcedefinitions",
+		Namespace: "kube-system",
+		Name:      "test-crd",
+	}
+
+	_, err := uc.ApplyResource(context.Background(), id, []byte("manifest"), ApplyOptions{})
+	if err == nil {
+		t.Fatal("expected error for cluster-scoped resource with namespace, got nil")
+	}
+
+	var invalidInput *ErrInvalidInput
+	if !errors.As(err, &invalidInput) {
+		t.Fatalf("expected ErrInvalidInput, got %T: %v", err, err)
+	}
+}
+
+// TestResourceUseCase_DeleteResource_NamespaceValidation tests namespace scope validation in DeleteResource.
+func TestResourceUseCase_DeleteResource_NamespaceValidation(t *testing.T) {
+	disco := &mockDiscoveryForResource{
+		lookupNamespaced: true, // namespace-scoped
+	}
+	repo := &mockResourceRepo{}
+	uc := NewResourceUseCase(disco, repo, nil)
+
+	id := &ResourceIdentifier{
+		Cluster:  "test-cluster",
+		Group:    "apps",
+		Version:  "v1",
+		Resource: "deployments",
+		Name:     "test-deploy",
+		// Missing namespace
+	}
+
+	err := uc.DeleteResource(context.Background(), id, DeleteOptions{})
+	if err == nil {
+		t.Fatal("expected error for namespace-scoped resource without namespace, got nil")
+	}
+
+	var invalidInput *ErrInvalidInput
+	if !errors.As(err, &invalidInput) {
+		t.Fatalf("expected ErrInvalidInput, got %T: %v", err, err)
+	}
+}
+
+// TestResourceUseCase_WatchResource_NamespaceValidation tests namespace scope validation in WatchResource.
+func TestResourceUseCase_WatchResource_NamespaceValidation(t *testing.T) {
+	disco := &mockDiscoveryForResource{
+		lookupNamespaced: false, // cluster-scoped
+	}
+	repo := &mockResourceRepo{}
+	uc := NewResourceUseCase(disco, repo, nil)
+
+	id := &ResourceIdentifier{
+		Cluster:   "test-cluster",
+		Group:     "",
+		Version:   "v1",
+		Resource:  "nodes",
+		Namespace: "default", // should fail
+	}
+
+	_, err := uc.WatchResource(context.Background(), id, WatchOptions{})
+	if err == nil {
+		t.Fatal("expected error for cluster-scoped resource with namespace, got nil")
+	}
+
+	var invalidInput *ErrInvalidInput
+	if !errors.As(err, &invalidInput) {
+		t.Fatalf("expected ErrInvalidInput, got %T: %v", err, err)
+	}
+}
+
+// mockResourceRepo is a minimal mock for ResourceRepo.
+type mockResourceRepo struct{}
+
+func (m *mockResourceRepo) List(context.Context, string, schema.GroupVersionResource, string, ListOptions) (*unstructured.UnstructuredList, error) {
+	return &unstructured.UnstructuredList{}, nil
+}
+
+func (m *mockResourceRepo) Get(context.Context, string, schema.GroupVersionResource, string, string) (*unstructured.Unstructured, error) {
+	return &unstructured.Unstructured{}, nil
+}
+
+func (m *mockResourceRepo) Create(context.Context, string, schema.GroupVersionResource, string, []byte) (*unstructured.Unstructured, error) {
+	return &unstructured.Unstructured{}, nil
+}
+
+func (m *mockResourceRepo) Apply(context.Context, string, schema.GroupVersionResource, string, string, []byte, ApplyOptions) (*unstructured.Unstructured, error) {
+	return &unstructured.Unstructured{}, nil
+}
+
+func (m *mockResourceRepo) Delete(context.Context, string, schema.GroupVersionResource, string, string, DeleteOptions) error {
+	return nil
+}
+
+func (m *mockResourceRepo) Watch(context.Context, string, schema.GroupVersionResource, string, WatchOptions) (Watcher, error) {
+	return nil, nil
+}
+
+func (m *mockResourceRepo) ListEvents(context.Context, string, string, ListOptions) (*unstructured.UnstructuredList, error) {
+	return &unstructured.UnstructuredList{}, nil
+}
+
+// contains checks if a string contains a substring.
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > len(substr) && containsAt(s, substr))
+}
+
+func containsAt(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/core/runtime.go
+++ b/internal/core/runtime.go
@@ -356,7 +356,7 @@ func (uc *RuntimeUseCase) GetScale(ctx context.Context, id *ResourceIdentifier) 
 	if id.Name == "" {
 		return 0, &ErrInvalidInput{Field: "name", Message: "resource name is required"}
 	}
-	gvr, err := id.lookupGVR(ctx, uc.discovery)
+	gvr, _, err := id.lookupGVR(ctx, uc.discovery)
 	if err != nil {
 		return 0, err
 	}
@@ -372,7 +372,7 @@ func (uc *RuntimeUseCase) Scale(ctx context.Context, id *ResourceIdentifier, rep
 	if replicas < 0 {
 		return 0, &ErrInvalidInput{Field: "replicas", Message: "must be non-negative"}
 	}
-	gvr, err := id.lookupGVR(ctx, uc.discovery)
+	gvr, _, err := id.lookupGVR(ctx, uc.discovery)
 	if err != nil {
 		return 0, err
 	}
@@ -405,7 +405,7 @@ func (uc *RuntimeUseCase) Restart(ctx context.Context, id *ResourceIdentifier) e
 	if id.Name == "" {
 		return &ErrInvalidInput{Field: "name", Message: "resource name is required"}
 	}
-	gvr, err := id.lookupGVR(ctx, uc.discovery)
+	gvr, _, err := id.lookupGVR(ctx, uc.discovery)
 	if err != nil {
 		return err
 	}
@@ -430,7 +430,7 @@ func (uc *RuntimeUseCase) SubResourceAction(ctx context.Context, id *ResourceIde
 		return nil, &ErrInvalidInput{Field: "method", Message: "must be PUT or POST"}
 	}
 
-	gvr, err := id.lookupGVR(ctx, uc.discovery)
+	gvr, _, err := id.lookupGVR(ctx, uc.discovery)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/core/runtime_test.go
+++ b/internal/core/runtime_test.go
@@ -76,6 +76,10 @@ func (m *mockDiscoveryForRuntime) SupportsWatchList(context.Context, string) (bo
 	return false, nil
 }
 
+func (m *mockDiscoveryForRuntime) IsNamespacedResource(context.Context, string, schema.GroupVersionResource) (bool, error) {
+	return true, nil
+}
+
 // mockHelmRepoForRuntime implements HelmRepo for runtime tests.
 type mockHelmRepoForRuntime struct{}
 

--- a/internal/core/runtime_test.go
+++ b/internal/core/runtime_test.go
@@ -53,11 +53,11 @@ type mockDiscoveryForRuntime struct {
 	lookupErr error
 }
 
-func (m *mockDiscoveryForRuntime) LookupResource(_ context.Context, _, group, ver, resource, _ string) (schema.GroupVersionResource, error) {
+func (m *mockDiscoveryForRuntime) LookupResource(_ context.Context, _, group, ver, resource, _ string) (schema.GroupVersionResource, bool, error) {
 	if m.lookupErr != nil {
-		return schema.GroupVersionResource{}, m.lookupErr
+		return schema.GroupVersionResource{}, false, m.lookupErr
 	}
-	return schema.GroupVersionResource{Group: group, Version: ver, Resource: resource}, nil
+	return schema.GroupVersionResource{Group: group, Version: ver, Resource: resource}, true, nil
 }
 
 func (m *mockDiscoveryForRuntime) ServerResources(context.Context, string) ([]*metav1.APIResourceList, error) {
@@ -74,10 +74,6 @@ func (m *mockDiscoveryForRuntime) ServerVersion(context.Context, string) (*versi
 
 func (m *mockDiscoveryForRuntime) SupportsWatchList(context.Context, string) (bool, error) {
 	return false, nil
-}
-
-func (m *mockDiscoveryForRuntime) IsNamespacedResource(context.Context, string, schema.GroupVersionResource) (bool, error) {
-	return true, nil
 }
 
 // mockHelmRepoForRuntime implements HelmRepo for runtime tests.

--- a/internal/providers/kubernetes/discovery_client.go
+++ b/internal/providers/kubernetes/discovery_client.go
@@ -130,6 +130,31 @@ func (d *discoveryClient) SupportsWatchList(ctx context.Context, cluster string)
 	return kubeVersion.GreaterThanEqual(minWatchListVersion), nil
 }
 
+// IsNamespacedResource reports whether the given resource is
+// namespace-scoped (true) or cluster-scoped (false).
+func (d *discoveryClient) IsNamespacedResource(ctx context.Context, cluster string, gvr schema.GroupVersionResource) (bool, error) {
+	client, err := d.client(ctx, cluster)
+	if err != nil {
+		return false, err
+	}
+
+	resources, err := client.ServerResourcesForGroupVersion(gvr.GroupVersion().String())
+	if err != nil {
+		return false, wrapK8sError(err)
+	}
+
+	for i := range resources.APIResources {
+		if resources.APIResources[i].Name == gvr.Resource {
+			return resources.APIResources[i].Namespaced, nil
+		}
+	}
+
+	return false, wrapK8sError(apierrors.NewNotFound(schema.GroupResource{
+		Group:    gvr.Group,
+		Resource: gvr.Resource,
+	}, ""))
+}
+
 // client returns a fresh discovery client for the given cluster with
 // impersonation headers set for the calling user. A new client is
 // created per request because each request may carry different

--- a/internal/providers/kubernetes/discovery_client.go
+++ b/internal/providers/kubernetes/discovery_client.go
@@ -39,12 +39,13 @@ func NewDiscoveryClient(kubernetes *Kubernetes) core.DiscoveryClient {
 var _ core.DiscoveryClient = (*discoveryClient)(nil)
 
 // LookupResource verifies that the given group/version/resource triple
-// exists on the target cluster. It returns the validated GVR or a
-// BadRequest error if the resource is not recognized.
-func (d *discoveryClient) LookupResource(ctx context.Context, cluster, group, version, resource, subresource string) (schema.GroupVersionResource, error) {
+// exists on the target cluster and returns whether it is namespace-scoped.
+// It returns the validated GVR, the namespace scope flag, or a BadRequest
+// error if the resource is not recognized.
+func (d *discoveryClient) LookupResource(ctx context.Context, cluster, group, version, resource, subresource string) (schema.GroupVersionResource, bool, error) {
 	client, err := d.client(ctx, cluster)
 	if err != nil {
-		return schema.GroupVersionResource{}, err
+		return schema.GroupVersionResource{}, false, err
 	}
 
 	gvr := schema.GroupVersionResource{
@@ -55,7 +56,7 @@ func (d *discoveryClient) LookupResource(ctx context.Context, cluster, group, ve
 
 	resources, err := client.ServerResourcesForGroupVersion(gvr.GroupVersion().String())
 	if err != nil {
-		return schema.GroupVersionResource{}, wrapK8sError(err)
+		return schema.GroupVersionResource{}, false, wrapK8sError(err)
 	}
 
 	target := resource
@@ -65,10 +66,10 @@ func (d *discoveryClient) LookupResource(ctx context.Context, cluster, group, ve
 
 	for i := range resources.APIResources {
 		if resources.APIResources[i].Name == target {
-			return gvr, nil
+			return gvr, resources.APIResources[i].Namespaced, nil
 		}
 	}
-	return schema.GroupVersionResource{}, wrapK8sError(apierrors.NewBadRequest(fmt.Sprintf("unable to recognize resource %s", gvr)))
+	return schema.GroupVersionResource{}, false, wrapK8sError(apierrors.NewBadRequest(fmt.Sprintf("unable to recognize resource %s", gvr)))
 }
 
 // ServerResources returns the full list of API resources available on
@@ -128,31 +129,6 @@ func (d *discoveryClient) SupportsWatchList(ctx context.Context, cluster string)
 	}
 
 	return kubeVersion.GreaterThanEqual(minWatchListVersion), nil
-}
-
-// IsNamespacedResource reports whether the given resource is
-// namespace-scoped (true) or cluster-scoped (false).
-func (d *discoveryClient) IsNamespacedResource(ctx context.Context, cluster string, gvr schema.GroupVersionResource) (bool, error) {
-	client, err := d.client(ctx, cluster)
-	if err != nil {
-		return false, err
-	}
-
-	resources, err := client.ServerResourcesForGroupVersion(gvr.GroupVersion().String())
-	if err != nil {
-		return false, wrapK8sError(err)
-	}
-
-	for i := range resources.APIResources {
-		if resources.APIResources[i].Name == gvr.Resource {
-			return resources.APIResources[i].Namespaced, nil
-		}
-	}
-
-	return false, wrapK8sError(apierrors.NewNotFound(schema.GroupResource{
-		Group:    gvr.Group,
-		Resource: gvr.Resource,
-	}, ""))
 }
 
 // client returns a fresh discovery client for the given cluster with


### PR DESCRIPTION
Add pre-validation in the use case layer to provide clear 400 Bad Request errors when namespace parameter doesn't match resource scope, instead of letting Kubernetes API return confusing 404 errors.

Changes:
- Add IsNamespacedResource method to DiscoveryClient interface
- Implement IsNamespacedResource in discoveryClient using K8s discovery API
- Add validateNamespaceScope helper method to ResourceIdentifier
- Apply namespace scope validation to all CRUD operations:
  * ListResources
  * GetResource
  * DescribeResource
  * CreateResource
  * ApplyResource
  * DeleteResource
  * WatchResource
- Update test mocks to implement new interface method

This improves the API Gateway behavior by:
- Returning 400 (Bad Request) instead of 404 (Not Found) for scope mismatches
- Providing clear error messages (e.g., "resource 'customresourcedefinitions' is cluster-scoped and cannot have a namespace")
- Validating parameters before making unnecessary K8s API calls

Example scenarios now handled correctly:
- Creating a CRD with namespace → 400 with clear message
- Creating a Pod without namespace → 400 with clear message