### PR TITLE
fix(resource): filter managedFields in Watch API output

### DIFF
--- a/internal/handler/resource.go
+++ b/internal/handler/resource.go
@@ -334,6 +334,10 @@ func processEvent(event core.WatchEvent) (*pb.WatchEvent, error) {
 			return nil, fmt.Errorf("nil object for event type %s", event.Type)
 		}
 
+		// Strip noisy metadata (managedFields, last-applied-configuration)
+		// before serializing to protobuf, consistent with List API behavior.
+		cleanObject(event.Object)
+
 		resource, err := toProtoResource(event.Object)
 		if err != nil {
 			return nil, fmt.Errorf("convert resource for event type %s: %w", event.Type, err)

--- a/internal/handler/resource.go
+++ b/internal/handler/resource.go
@@ -110,13 +110,6 @@ func (s *ResourceService) List(ctx context.Context, req *pb.ListRequest) (*pb.Li
 		return nil, domainErrorToConnectError(err)
 	}
 
-	// Strip noisy metadata (managedFields, last-applied-configuration)
-	// before serializing to protobuf. This is a presentation concern
-	// that belongs in the handler layer, not the domain use-case.
-	for i := range resources.Items {
-		cleanObject(resources.Items[i].Object)
-	}
-
 	pbResources, err := toProtoResources(resources.Items)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
@@ -334,10 +327,6 @@ func processEvent(event core.WatchEvent) (*pb.WatchEvent, error) {
 			return nil, fmt.Errorf("nil object for event type %s", event.Type)
 		}
 
-		// Strip noisy metadata (managedFields, last-applied-configuration)
-		// before serializing to protobuf, consistent with List API behavior.
-		cleanObject(event.Object)
-
 		resource, err := toProtoResource(event.Object)
 		if err != nil {
 			return nil, fmt.Errorf("convert resource for event type %s: %w", event.Type, err)
@@ -450,8 +439,15 @@ func toProtoResources(list []unstructured.Unstructured) ([]*pb.Resource, error) 
 }
 
 // toProtoResource wraps a raw Kubernetes object map in a protobuf
-// Resource message.
+// Resource message. It strips noisy metadata (managedFields,
+// last-applied-configuration) before serializing to ensure a
+// consistent presentation across all endpoints.
 func toProtoResource(obj map[string]any) (*pb.Resource, error) {
+	// Clean the object in-place before conversion. This is safe
+	// because Kubernetes client-go provides fresh objects for each
+	// API call and watch event.
+	cleanObject(obj)
+
 	object, err := structpb.NewStruct(obj)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
The Watch API was not filtering out managedFields from ConfigMaps and other resources, while the List API correctly removed them. This caused inconsistent YAML output between the two APIs.

Added cleanObject() call in processEvent() to strip managedFields and last-applied-configuration annotation before serializing watch events, making Watch API behavior consistent with List API.