### PR TITLE
feat(rbac): add ClusterRole for storage class viewer

### DIFF
--- a/internal/providers/manifest/renderer.go
+++ b/internal/providers/manifest/renderer.go
@@ -208,6 +208,22 @@ rules:
     verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  name: otterscale-storageclass-viewer
+rules:
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - storageclasses
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: otterscale-node-reader

--- a/internal/providers/manifest/renderer.go
+++ b/internal/providers/manifest/renderer.go
@@ -208,17 +208,6 @@ rules:
     verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  labels:
-    rbac.authorization.k8s.io/aggregate-to-view: "true"
-  name: otterscale-storageclass-viewer
-rules:
-  - apiGroups: ["storage.k8s.io"]
-    resources: ["storageclasses"]
-    verbs: ["get", "list", "watch"]
----
-apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: otterscale-node-reader
@@ -229,6 +218,28 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: otterscale-node-reader
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: otterscale-storageclass-reader
+rules:
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: otterscale-storageclass-reader
+subjects:
+  - kind: Group
+    name: system:authenticated
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: otterscale-storageclass-reader
   apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: apps/v1

--- a/internal/providers/manifest/renderer.go
+++ b/internal/providers/manifest/renderer.go
@@ -214,14 +214,9 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
   name: otterscale-storageclass-viewer
 rules:
-  - apiGroups:
-      - storage.k8s.io
-    resources:
-      - storageclasses
-    verbs:
-      - get
-      - list
-      - watch
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
Added a new ClusterRole named 'otterscale-storageclass-viewer' to allow viewing of storage classes in Kubernetes. This role includes permissions for 'get', 'list', and 'watch' actions on the 'storageclasses' resource within the 'storage.k8s.io' API group.