### PR TITLE
chore: remove test trivy job on PR event & add trivy sarif upload on release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,46 +72,6 @@ jobs:
           format: table
           exit-code: "1"
 
-  trivy-sarif-preview:
-    runs-on: ubuntu-24.04
-    permissions:
-      contents: read
-      security-events: write
-    steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
-        with:
-          egress-policy: audit
-
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Generate non-empty Trivy SARIF preview
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
-        with:
-          image-ref: knqyf263/vuln-image:1.2.3
-          scanners: vuln
-          vuln-type: os,library
-          severity: HIGH,CRITICAL
-          ignore-unfixed: false
-          format: sarif
-          output: trivy-preview-results.sarif
-          exit-code: "0"
-
-      - name: Upload Trivy SARIF preview artifact
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: trivy-preview-sarif
-          path: trivy-preview-results.sarif
-          retention-days: 5
-
-      - name: Upload Trivy SARIF preview to code scanning
-        if: always()
-        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
-        with:
-          sarif_file: trivy-preview-results.sarif
-          category: trivy-preview-vulnerable-image
-
   lint:
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/delivery-report.yml
+++ b/.github/workflows/delivery-report.yml
@@ -37,8 +37,22 @@ jobs:
             image_ref="ghcr.io/${GITHUB_REPOSITORY}:${tag}"
           fi
 
+          image_name_tag="${image_ref##*/}"
+          if [ "$image_name_tag" != "${image_name_tag%@*}" ]; then
+            image_name="${image_name_tag%@*}"
+            image_digest="${image_name_tag#*@}"
+            image_digest="${image_digest//:/-}"
+            report_basename="${image_name}-${image_digest}"
+          else
+            report_basename="$image_name_tag"
+          fi
+          artifact_basename="$(echo "$report_basename" | sed 's/[^A-Za-z0-9._-]/-/g')"
+
           echo "image_ref=$image_ref" >> "$GITHUB_OUTPUT"
+          echo "report_basename=$report_basename" >> "$GITHUB_OUTPUT"
+          echo "artifact_basename=$artifact_basename" >> "$GITHUB_OUTPUT"
           echo "Image reference: $image_ref"
+          echo "Report basename: $report_basename"
 
       - name: Log in to the Container registry
         if: startsWith(steps.image.outputs.image_ref, 'ghcr.io/')
@@ -74,7 +88,7 @@ jobs:
             echo "============"
             echo
             cat trivy-image-cve-scan.txt
-          } > image-cve-scan-report.txt
+          } > "${REPORT_BASENAME}-cve-scan-report.txt"
 
           {
             echo "# Image CVE Scan Report"
@@ -91,36 +105,37 @@ jobs:
             echo '```text'
             cat trivy-image-cve-scan.txt
             echo '```'
-          } > image-cve-scan-report.md
+          } > "${REPORT_BASENAME}-cve-scan-report.md"
 
           {
             echo "## Image CVE Scan Report"
             echo
             echo "### Markdown"
             echo
-            cat image-cve-scan-report.md
+            cat "${REPORT_BASENAME}-cve-scan-report.md"
             echo
             echo "### Text"
             echo
             echo '```text'
-            cat image-cve-scan-report.txt
+            cat "${REPORT_BASENAME}-cve-scan-report.txt"
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
         env:
           IMAGE_REF: ${{ steps.image.outputs.image_ref }}
+          REPORT_BASENAME: ${{ steps.image.outputs.report_basename }}
 
       - name: Upload text image scan report
-        if: always() && hashFiles('image-cve-scan-report.txt') != ''
+        if: always() && hashFiles(format('{0}-cve-scan-report.txt', steps.image.outputs.report_basename)) != ''
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: image-cve-scan-report-text
-          path: image-cve-scan-report.txt
+          name: ${{ steps.image.outputs.artifact_basename }}-cve-scan-report-text
+          path: ${{ steps.image.outputs.report_basename }}-cve-scan-report.txt
           retention-days: 30
 
       - name: Upload Markdown image scan report
-        if: always() && hashFiles('image-cve-scan-report.md') != ''
+        if: always() && hashFiles(format('{0}-cve-scan-report.md', steps.image.outputs.report_basename)) != ''
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: image-cve-scan-report-markdown
-          path: image-cve-scan-report.md
+          name: ${{ steps.image.outputs.artifact_basename }}-cve-scan-report-markdown
+          path: ${{ steps.image.outputs.report_basename }}-cve-scan-report.md
           retention-days: 30

--- a/.github/workflows/delivery-report.yml
+++ b/.github/workflows/delivery-report.yml
@@ -46,11 +46,10 @@ jobs:
           else
             report_basename="$image_name_tag"
           fi
-          artifact_basename="$(echo "$report_basename" | sed 's/[^A-Za-z0-9._-]/-/g')"
+          report_basename="$(echo "$report_basename" | sed 's/[^A-Za-z0-9._-]/_/g')"
 
           echo "image_ref=$image_ref" >> "$GITHUB_OUTPUT"
           echo "report_basename=$report_basename" >> "$GITHUB_OUTPUT"
-          echo "artifact_basename=$artifact_basename" >> "$GITHUB_OUTPUT"
           echo "Image reference: $image_ref"
           echo "Report basename: $report_basename"
 
@@ -128,7 +127,7 @@ jobs:
         if: always() && hashFiles(format('{0}-cve-scan-report.txt', steps.image.outputs.report_basename)) != ''
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: ${{ steps.image.outputs.artifact_basename }}-cve-scan-report-text
+          name: ${{ steps.image.outputs.report_basename }}-cve-scan-report-text
           path: ${{ steps.image.outputs.report_basename }}-cve-scan-report.txt
           retention-days: 30
 
@@ -136,6 +135,6 @@ jobs:
         if: always() && hashFiles(format('{0}-cve-scan-report.md', steps.image.outputs.report_basename)) != ''
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: ${{ steps.image.outputs.artifact_basename }}-cve-scan-report-markdown
+          name: ${{ steps.image.outputs.report_basename }}-cve-scan-report-markdown
           path: ${{ steps.image.outputs.report_basename }}-cve-scan-report.md
           retention-days: 30

--- a/.github/workflows/delivery-report.yml
+++ b/.github/workflows/delivery-report.yml
@@ -1,7 +1,6 @@
 name: Image CVE Scan Report
 
 on:
-  pull_request:
   workflow_dispatch:
     inputs:
       image_ref:

--- a/.github/workflows/delivery-report.yml
+++ b/.github/workflows/delivery-report.yml
@@ -1,0 +1,126 @@
+name: Image CVE Scan Report
+
+on:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      image_ref:
+        description: "Container image reference to scan. Defaults to the latest GitHub release image."
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  generate-table-report:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Resolve image reference
+        id: image
+        env:
+          GH_TOKEN: ${{ github.token }}
+          INPUT_IMAGE_REF: ${{ inputs.image_ref }}
+        run: |
+          if [ -n "$INPUT_IMAGE_REF" ]; then
+            image_ref="$INPUT_IMAGE_REF"
+          else
+            tag="$(gh release view --repo "$GITHUB_REPOSITORY" --json tagName --jq '.tagName')"
+            image_ref="ghcr.io/${GITHUB_REPOSITORY}:${tag}"
+          fi
+
+          echo "image_ref=$image_ref" >> "$GITHUB_OUTPUT"
+          echo "Image reference: $image_ref"
+
+      - name: Log in to the Container registry
+        if: startsWith(steps.image.outputs.image_ref, 'ghcr.io/')
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate Trivy table image scan report
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: ${{ steps.image.outputs.image_ref }}
+          scanners: vuln
+          vuln-type: os,library
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          format: table
+          output: trivy-image-cve-scan.txt
+          exit-code: "0"
+
+      - name: Write image scan reports
+        run: |
+          {
+            echo "Image CVE Scan Report"
+            echo
+            echo "Image: ${IMAGE_REF}"
+            echo "Repository: ${GITHUB_REPOSITORY}"
+            echo "Workflow run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+            echo "Scope: Fixed HIGH and CRITICAL OS/library vulnerabilities"
+            echo
+            echo "Trivy Result"
+            echo "============"
+            echo
+            cat trivy-image-cve-scan.txt
+          } > image-cve-scan-report.txt
+
+          {
+            echo "# Image CVE Scan Report"
+            echo
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+            echo "| Image | \`${IMAGE_REF}\` |"
+            echo "| Repository | \`${GITHUB_REPOSITORY}\` |"
+            echo "| Workflow run | [${GITHUB_RUN_ID}](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}) |"
+            echo "| Scope | Fixed HIGH and CRITICAL OS/library vulnerabilities |"
+            echo
+            echo "## Trivy Result"
+            echo
+            echo '```text'
+            cat trivy-image-cve-scan.txt
+            echo '```'
+          } > image-cve-scan-report.md
+
+          {
+            echo "## Image CVE Scan Report"
+            echo
+            echo "### Markdown"
+            echo
+            cat image-cve-scan-report.md
+            echo
+            echo "### Text"
+            echo
+            echo '```text'
+            cat image-cve-scan-report.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+        env:
+          IMAGE_REF: ${{ steps.image.outputs.image_ref }}
+
+      - name: Upload text image scan report
+        if: always() && hashFiles('image-cve-scan-report.txt') != ''
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: image-cve-scan-report-text
+          path: image-cve-scan-report.txt
+          retention-days: 30
+
+      - name: Upload Markdown image scan report
+        if: always() && hashFiles('image-cve-scan-report.md') != ''
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: image-cve-scan-report-markdown
+          path: image-cve-scan-report.md
+          retention-days: 30

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      security-events: write
       attestations: write
       id-token: write
       artifact-metadata: write
@@ -54,6 +55,27 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             VERSION=${{ github.event.release.tag_name }}
+
+      - name: Generate Trivy SARIF image scan report
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.push.outputs.digest }}
+          scanners: vuln
+          vuln-type: os,library
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          format: sarif
+          output: results.sarif
+          exit-code: "0"
+          limit-severities-for-sarif: true
+
+      - name: Upload Trivy SARIF
+        if: always() && hashFiles('results.sarif') != ''
+        continue-on-error: true
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        with:
+          sarif_file: results.sarif
+          category: trivy-release-image
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0


### PR DESCRIPTION
1. Remove trivy job for testing.
2. Add uploading sarif process on release, make sure "Code scanning" tab can display code scanning results.